### PR TITLE
Fix issue with client connecting on /new

### DIFF
--- a/client/bin/smee.js
+++ b/client/bin/smee.js
@@ -1,17 +1,27 @@
 #!/usr/bin/env node
 
 const program = require('commander')
+
 const Client = require('..')
 
 program
   .usage('[options]')
-  .option('-u, --url <url>', 'URL of the webhook proxy service', 'https://smee.io/new')
+  .option('-u, --url <url>', 'URL of the webhook proxy service. Default: https://smee.io/new')
   .option('-p, --port <n>', 'Local HTTP server port', process.env.PORT || 3000)
   .option('-P, --path <path>', 'URL path to post proxied requests to`', '/')
   .parse(process.argv)
 
-const source = program.url
 const target = `http://127.0.0.1:${program.port}${program.path}`
 
-const client = new Client({source, target})
-client.start()
+async function setup () {
+  let source = program.url
+
+  if (!source) {
+    source = await Client.createChannel()
+  }
+
+  const client = new Client({source, target})
+  client.start()
+}
+
+setup()

--- a/client/index.js
+++ b/client/index.js
@@ -1,7 +1,7 @@
 const EventSource = require('eventsource')
 const superagent = require('superagent')
 
-module.exports = class Client {
+class Client {
   constructor ({source, target, logger = console}) {
     this.source = source
     this.target = target
@@ -46,10 +46,18 @@ module.exports = class Client {
     events.addEventListener('open', this.onopen.bind(this))
     events.addEventListener('error', this.onerror.bind(this))
 
-    this.logger.info(`Proxying requests from ${this.source} to ${this.target}`)
+    this.logger.info(`Forwarding ${this.source} to ${this.target}`)
 
     this.events = events
 
     return events
   }
 }
+
+Client.createChannel = async () => {
+  return superagent.head('https://smee.io/new').redirects(0).catch((err, res) => {
+    return err.response.headers.location
+  })
+}
+
+module.exports = Client

--- a/client/test/index.test.js
+++ b/client/test/index.test.js
@@ -70,7 +70,7 @@ describe('client', () => {
       // Wait for event source to be ready
       client.addEventListener('ready', () => {
         expect(client.url).not.toMatch(/\/new$/)
-        expect(client.url).toMatch(/\/(\w+)/)
+        expect(client.url).toMatch(/\/([\w-]+)$/)
         done()
       })
     })

--- a/client/test/index.test.js
+++ b/client/test/index.test.js
@@ -57,22 +57,15 @@ describe('client', () => {
     })
   })
 
-  describe('/new', () => {
-    beforeEach(() => {
-      client = new Client({
-        source: `${host}/new`,
-        target: targetUrl,
-        logger
-      }).start()
-    })
-
-    test('connects to a new channel', async (done) => {
-      // Wait for event source to be ready
-      client.addEventListener('ready', () => {
-        expect(client.url).not.toMatch(/\/new$/)
-        expect(client.url).toMatch(/\/([\w-]+)$/)
-        done()
+  describe('createChannel', () => {
+    test('returns a new channel', async () => {
+      const req = nock('https://smee.io').head('/new').reply(302, '', {
+        Location: 'https://smee.io/abc123'
       })
+
+      const channel = await Client.createChannel()
+      expect(channel).toEqual('https://smee.io/abc123')
+      expect(req.isDone()).toBe(true)
     })
   })
 })

--- a/client/test/index.test.js
+++ b/client/test/index.test.js
@@ -23,6 +23,11 @@ describe('client', () => {
     })
   })
 
+  afterEach(() => {
+    proxy && proxy.close()
+    client && client.close()
+  })
+
   describe('connecting to a channel', () => {
     beforeEach((done) => {
       channel = '/fake-channel'
@@ -33,11 +38,6 @@ describe('client', () => {
       }).start()
       // Wait for event source to be ready
       client.addEventListener('ready', () => done())
-    })
-
-    afterEach(() => {
-      proxy && proxy.close()
-      client && client.close()
     })
 
     test('POST /:channel forwards to target url', async (done) => {

--- a/lib/server.js
+++ b/lib/server.js
@@ -32,7 +32,7 @@ module.exports = () => {
       .replace(/\+/g, '-')
       .replace(/\//g, '_')
       .replace(/=/g, '~')
-    res.redirect(307, channel)
+    res.redirect(307, `${req.protocol}://${req.get('host')}/${channel}`)
   })
 
   app.get('/:channel', (req, res, next) => {

--- a/lib/server.js
+++ b/lib/server.js
@@ -32,7 +32,7 @@ module.exports = () => {
       .replace(/\+/g, '-')
       .replace(/\//g, '_')
       .replace(/=/g, '~')
-    res.redirect(301, channel)
+    res.redirect(307, channel)
   })
 
   app.get('/:channel', (req, res, next) => {

--- a/lib/server.js
+++ b/lib/server.js
@@ -28,13 +28,16 @@ module.exports = () => {
   })
 
   app.get('/new', (req, res) => {
+    const protocol = req.headers['x-forwarded-proto'] || req.protocol
+    const host = req.headers['x-forwarded-host'] || req.get('host')
     const channel = crypto
       .randomBytes(12)
       .toString('base64')
       .replace(/\+/g, '-')
       .replace(/\//g, '_')
       .replace(/=/g, '~')
-    res.redirect(307, `${req.protocol}://${req.get('host')}/${channel}`)
+
+    res.redirect(307, `${protocol}://${host}/${channel}`)
   })
 
   app.get('/:channel', (req, res, next) => {

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -35,7 +35,7 @@ describe('server', () => {
     it('redirects from /new to /TOKEN', async () => {
       const res = await request(server).get('/new')
       expect(res.status).toBe(307)
-      expect(res.headers.location).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/\w+$/)
+      expect(res.headers.location).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/[\w-]+$/)
     })
   })
 

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -35,7 +35,7 @@ describe('server', () => {
     it('redirects from /new to /TOKEN', async () => {
       const res = await request(server).get('/new')
       expect(res.status).toBe(307)
-      expect(typeof res.headers.location).toBe('string')
+      expect(res.headers.location).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/\w+$/)
     })
   })
 

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -34,7 +34,7 @@ describe('server', () => {
   describe('GET /new', () => {
     it('redirects from /new to /TOKEN', async () => {
       const res = await request(server).get('/new')
-      expect(res.status).toBe(301)
+      expect(res.status).toBe(307)
       expect(typeof res.headers.location).toBe('string')
     })
   })


### PR DESCRIPTION
`GET /new` was returning a relative redirect to the new channel name, but [EventSource](https://npm.im/eventsource) doesn't appear to be smart enough to inherit the original request path. This adds tests for the client to ensure it can properly follow the redirect from `/new`, and fixes the server to return an absolute redirect.

