### PR TITLE
Rename to smee-client

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -1,0 +1,41 @@
+# smee-client
+
+Client and CLI for smee.io, a service that delivers webhooks to your local development environment.
+
+## Installation
+
+Install the client with:
+
+```
+$ npm install -g smee-client
+```
+
+## Usage
+
+### CLI
+
+The `smee` command will forward webhooks from smee.io to your local development environment.
+
+```
+$ smee
+```
+
+Run `smee --help` for usage.
+
+### Node Client
+
+```js
+const SmeeClient = require('smee-client')
+
+const smee = new SmeeClient({
+  source: 'https://smee.io/abc123',
+  target: 'http://localhost:3000/events',
+  logger: console
+})
+
+const events = smee.start()
+
+// Stop forwarding events
+events.close()
+
+```

--- a/client/package.json
+++ b/client/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "smee-cli",
+  "name": "smee-client",
   "version": "1.0.0",
   "description": "Client to proxy webhooks to local host",
   "main": "index.js",


### PR DESCRIPTION
I pinged the owner of `smee` again, but still haven't heard anything back. In the mean time, since this package can also be used as a client in a node app, calling it `smee-client` makes more sense than `smee-cli`.

This renames it and adds a README.

Closes #19 
  