### PR TITLE
Downgrade babel-eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "autoprefixer": "^7.1.6",
     "babel-core": "^6.26.0",
-    "babel-eslint": "^8.0.1",
+    "babel-eslint": "^7.2.3",
     "babel-loader": "^7.1.2",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",


### PR DESCRIPTION
There seems to be a compatibility error between `standard` and `babel-eslint`, resulting in false-positives for "undefined" static variables on ES6 classes. It does not occur in `babel-eslint@^7` (we are currently on v8), so I've downgraded our installed version.

💥 https://github.com/babel/babel-eslint/issues/487 💥 