### PR TITLE
Replace 🤖 with SVG ❤

### DIFF
--- a/server/public/index.html
+++ b/server/public/index.html
@@ -42,8 +42,8 @@
     <p class="lead text-center col-12 col-md-8 mx-auto">Tell your webhook source to send payloads to your <strong>smee.io</strong> channel, then either use the <a href="https://github.com/probot/smee/tree/master/client" target="_blank" rel="noopener noreferrer">smee client</a> or, if you're using <a href="https://probot.github.io" target="_blank" rel="noopener noreferrer">Probot</a> to build a GitHub App, just <a href="https://probot.github.io/docs/development/#configure-a-github-app">set the environment variable</a>.</p>
   </main>
 
-  <footer class="border-top text-center py-4">
-    Made with 🤖 by the <a href="https://github.com/probot" target="_blank" rel="noopener noreferrer">Probot team</a>.
+  <footer class="border-top text-center py-4 text-gray">
+    Made with <svg height="16" class="octicon octicon-heart" viewBox="0 0 12 16" version="1.1" width="12" aria-hidden="true"><path fill-rule="evenodd" d="M11.2 3c-.52-.63-1.25-.95-2.2-1-.97 0-1.69.42-2.2 1-.51.58-.78.92-.8 1-.02-.08-.28-.42-.8-1-.52-.58-1.17-1-2.2-1-.95.05-1.69.38-2.2 1-.52.61-.78 1.28-.8 2 0 .52.09 1.52.67 2.67C1.25 8.82 3.01 10.61 6 13c2.98-2.39 4.77-4.17 5.34-5.33C11.91 6.51 12 5.5 12 5c-.02-.72-.28-1.39-.8-2.02V3z"></path></svg> by the <a href="https://github.com/probot" target="_blank" rel="noopener noreferrer">Probot team</a>.
   </footer>
 
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-102577034-3"></script>

--- a/server/tests/__snapshots__/server.test.js.snap
+++ b/server/tests/__snapshots__/server.test.js.snap
@@ -45,8 +45,8 @@ exports[`server GET / returns the proper HTML 1`] = `
     <p class=\\"lead text-center col-12 col-md-8 mx-auto\\">Tell your webhook source to send payloads to your <strong>smee.io</strong> channel, then either use the <a href=\\"https://github.com/probot/smee/tree/master/client\\" target=\\"_blank\\" rel=\\"noopener noreferrer\\">smee client</a> or, if you're using <a href=\\"https://probot.github.io\\" target=\\"_blank\\" rel=\\"noopener noreferrer\\">Probot</a> to build a GitHub App, just <a href=\\"https://probot.github.io/docs/development/#configure-a-github-app\\">set the environment variable</a>.</p>
   </main>
 
-  <footer class=\\"border-top text-center py-4\\">
-    Made with 🤖 by the <a href=\\"https://github.com/probot\\" target=\\"_blank\\" rel=\\"noopener noreferrer\\">Probot team</a>.
+  <footer class=\\"border-top text-center py-4 text-gray\\">
+    Made with <svg height=\\"16\\" class=\\"octicon octicon-heart\\" viewBox=\\"0 0 12 16\\" version=\\"1.1\\" width=\\"12\\" aria-hidden=\\"true\\"><path fill-rule=\\"evenodd\\" d=\\"M11.2 3c-.52-.63-1.25-.95-2.2-1-.97 0-1.69.42-2.2 1-.51.58-.78.92-.8 1-.02-.08-.28-.42-.8-1-.52-.58-1.17-1-2.2-1-.95.05-1.69.38-2.2 1-.52.61-.78 1.28-.8 2 0 .52.09 1.52.67 2.67C1.25 8.82 3.01 10.61 6 13c2.98-2.39 4.77-4.17 5.34-5.33C11.91 6.51 12 5.5 12 5c-.02-.72-.28-1.39-.8-2.02V3z\\"></path></svg> by the <a href=\\"https://github.com/probot\\" target=\\"_blank\\" rel=\\"noopener noreferrer\\">Probot team</a>.
   </footer>
 
   <script async src=\\"https://www.googletagmanager.com/gtag/js?id=UA-102577034-3\\"></script>


### PR DESCRIPTION
@hiimbex reported that the emoji in the footer wasn't rendering properly on their machine. In switching over to an SVG, there isn't [an octicon](https://octicons.github.com/) that is a drop-in replacement for the Robot emoji (besides Hubot but thats not the same thing). So, because we ❤️ Probot, I've used the heart octicon.