### PR TITLE
Add more icons

### DIFF
--- a/server/src/components/ListItem.js
+++ b/server/src/components/ListItem.js
@@ -11,7 +11,19 @@ import {
   IssueClosedIcon,
   KebabHorizontalIcon,
   ClippyIcon,
-  SyncIcon
+  SyncIcon,
+  CommentIcon,
+  CheckIcon,
+  RepoForkedIcon,
+  EyeIcon,
+  ChecklistIcon,
+  CloudUploadIcon,
+  GlobeIcon,
+  HubotIcon,
+  MilestoneIcon,
+  ProjectIcon,
+  StopIcon,
+  NoteIcon
 } from 'react-octicons'
 import EventDescription from './EventDescription'
 import copy from 'copy-to-clipboard'
@@ -21,7 +33,23 @@ const iconMap = {
   pull_request: <GitPullRequestIcon />,
   label: <BookmarkIcon />,
   'issues.opened': <IssueOpenedIcon />,
-  'issues.closed': <IssueClosedIcon />
+  'issues.closed': <IssueClosedIcon />,
+  issue_comment: <CommentIcon />,
+  status: <CheckIcon />,
+  fork: <RepoForkedIcon />,
+  watch: <EyeIcon />,
+  check_run: <ChecklistIcon />,
+  check_suite: <ChecklistIcon />,
+  deployment: <CloudUploadIcon />,
+  deployment_status: <CloudUploadIcon />,
+  ping: <GlobeIcon />,
+  installation: <HubotIcon />,
+  installation_repositories: <HubotIcon />,
+  milestone: <MilestoneIcon />,
+  project: <ProjectIcon />,
+  project_card: <NoteIcon />,
+  project_column: <ProjectIcon />,
+  repository_vulnerability_alert: <StopIcon />
 }
 
 export default class ListItem extends Component {


### PR DESCRIPTION
I was getting tired of seeing so many 📦 icons for all the different payloads, so I've gone ahead and added some more special icons:

```
issue_comment
status
fork
watch
check_run
check_suite
deployment
deployment_status
ping
installation
installation_repositories
milestone
project
project_card
project_column
repository_vulnerability_alert
```

Given that this is a minor change and follows the initial plan for the UI, will 🚢 with one ✔️. My only concern is that the import block is getting a little large, but for tree-shaking that can't really be avoided (but please let me know if I'm wrong on that).