### PR TITLE
Pin events

### DIFF
--- a/server/src/components/App.js
+++ b/server/src/components/App.js
@@ -147,8 +147,8 @@ export default class App extends Component {
           <div className="container-md py-3 p-responsive">
             <div className="mb-2">
               <div className="d-flex flex-items-end mb-2">
-                <label htmlFor="search" className="d-flex flex-items-center f6 text-gray"><SearchIcon height={12} width={12} className="mr-1" /> Filter deliveries</label>
-                <a className="ml-2 f6" href="https://github.com/jonschlinkert/get-value" target="_blank" rel="noopener noreferrer">Uses the get-value syntax</a>
+                <label htmlFor="search" className="d-flex flex-items-center f6 text-gray"><SearchIcon height={12} width={12} className="mr-1" /> Filter by</label>
+                &nbsp;<a className="f6" href="https://github.com/jonschlinkert/get-value" target="_blank" rel="noopener noreferrer">get-value syntax</a>
 
                 <button onClick={this.clear} className="btn btn-sm btn-danger" style={{ marginLeft: 'auto' }}>Clear deliveries</button>
               </div>

--- a/server/src/components/App.js
+++ b/server/src/components/App.js
@@ -23,6 +23,7 @@ export default class App extends Component {
     }
 
     this.togglePinned = this.togglePinned.bind(this)
+    this.isPinned = this.isPinned.bind(this)
   }
 
   componentDidMount () {
@@ -99,8 +100,13 @@ export default class App extends Component {
     }
   }
 
+  isPinned (item) {
+    const id = item['x-github-delivery']
+    return this.state.pinnedDeliveries.includes(id)
+  }
+
   render () {
-    const { log, filter } = this.state
+    const { log, filter, pinnedDeliveries } = this.state
     let filtered = log
     if (filter) {
       filtered = log.filter(l => {
@@ -149,10 +155,18 @@ export default class App extends Component {
                 className="input input-lg width-full Box"
               />
             </div>
+            {pinnedDeliveries.length > 0 && (
+              <ul className="Box list-style-none pl-0 mb-2">
+                {filtered.filter(this.isPinned).map((item, i, arr) => {
+                  const id = item['x-github-delivery']
+                  return <ListItem key={id} pinned togglePinned={this.togglePinned} item={item} last={i === arr.length - 1} />
+                })}
+              </ul>
+            )}
             <ul className="Box list-style-none pl-0">
-              {filtered.map((item, i, arr) => {
+              {filtered.filter(item => !this.isPinned(item)).map((item, i, arr) => {
                 const id = item['x-github-delivery']
-                return <ListItem key={id} pinned={this.state.pinnedDeliveries.includes(id)} togglePinned={this.togglePinned} item={item} last={i === arr.length - 1} />
+                return <ListItem key={id} pinned={false} togglePinned={this.togglePinned} item={item} last={i === arr.length - 1} />
               })}
             </ul>
           </div>

--- a/server/src/components/App.js
+++ b/server/src/components/App.js
@@ -80,7 +80,7 @@ export default class App extends Component {
   clear () {
     if (confirm('Are you sure you want to clear the delivery log?')) {
       console.log('Clearing logs')
-      const filtered = this.state.log.filter(log => this.state.pinnedDeliveries.includes(log.id))
+      const filtered = this.state.log.filter(this.isPinned)
       this.setState({ log: filtered })
       if (filtered.length > 0) {
         localStorage.setItem(this.ref, JSON.stringify(filtered))

--- a/server/src/components/App.js
+++ b/server/src/components/App.js
@@ -12,8 +12,10 @@ export default class App extends Component {
 
     this.clear = this.clear.bind(this)
 
-    const ref = localStorage.getItem(`smee:log:${this.channel}`)
-    const pinnedRef = localStorage.getItem(`smee:log:${this.channel}:pinned`)
+    this.ref = `smee:log:${this.channel}`
+    this.pinnedRef = this.ref + ':pinned'
+    const ref = localStorage.getItem(this.ref)
+    const pinnedRef = localStorage.getItem(this.pinnedRef)
 
     this.state = {
       log: ref ? JSON.parse(ref) : [],
@@ -70,7 +72,7 @@ export default class App extends Component {
       this.setState({
         log: [json, ...this.state.log]
       }, () => {
-        localStorage.setItem(`smee:log:${this.channel}`, JSON.stringify(this.state.log.slice(0, this.storageLimit)))
+        localStorage.setItem(this.ref, JSON.stringify(this.state.log.slice(0, this.storageLimit)))
       })
     }
   }
@@ -78,26 +80,30 @@ export default class App extends Component {
   clear () {
     if (confirm('Are you sure you want to clear the delivery log?')) {
       console.log('Clearing logs')
-      this.setState({ log: this.state.log.filter(log => this.state.pinnedDeliveries.includes(log.id)) })
-      localStorage.removeItem(`smee:log:${this.channel}`)
+      const filtered = this.state.log.filter(log => this.state.pinnedDeliveries.includes(log.id))
+      this.setState({ log: filtered })
+      if (filtered.length > 0) {
+        localStorage.setItem(this.ref, JSON.stringify(filtered))
+      } else {
+        localStorage.removeItem(this.ref)
+      }
     }
   }
 
   togglePinned (id) {
     const deliveryId = this.state.pinnedDeliveries.indexOf(id)
+    let pinnedDeliveries
     if (deliveryId > -1) {
-      this.setState({ pinnedDeliveries: [
+      pinnedDeliveries = [
         ...this.state.pinnedDeliveries.slice(0, deliveryId),
         ...this.state.pinnedDeliveries.slice(deliveryId + 1)
-      ] })
+      ]
     } else {
-      this.setState({
-        pinnedDeliveries: [
-          ...this.state.pinnedDeliveries,
-          id
-        ]
-      })
+      pinnedDeliveries = [...this.state.pinnedDeliveries, id]
     }
+
+    this.setState({ pinnedDeliveries })
+    localStorage.setItem(this.pinnedRef, JSON.stringify(pinnedDeliveries))
   }
 
   isPinned (item) {

--- a/server/src/components/App.js
+++ b/server/src/components/App.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import ListItem from './ListItem'
 import get from 'get-value'
-import { AlertIcon, PulseIcon } from 'react-octicons'
+import { AlertIcon, PulseIcon, SearchIcon, PinIcon } from 'react-octicons'
 import Blank from './Blank'
 
 export default class App extends Component {
@@ -131,7 +131,7 @@ export default class App extends Component {
       <main>
         <div className="py-2 bg-gray-dark">
           <div className="container-md text-white p-responsive d-flex flex-items-center flex-justify-between">
-            <h1 className="f4">Recent Deliveries</h1>
+            <h1 className="f4">Webhook Deliveries</h1>
             <div className="flex-items-right tooltipped tooltipped-w" aria-label={stateString + ' to event stream'}>
               {this.state.connection
               ? <PulseIcon
@@ -147,7 +147,7 @@ export default class App extends Component {
           <div className="container-md py-3 p-responsive">
             <div className="mb-2">
               <div className="d-flex flex-items-end mb-2">
-                <label htmlFor="search">Filter deliveries</label>
+                <label htmlFor="search" className="d-flex flex-items-center f6 text-gray"><SearchIcon height={12} width={12} className="mr-1" /> Filter deliveries</label>
                 <a className="ml-2 f6" href="https://github.com/jonschlinkert/get-value" target="_blank" rel="noopener noreferrer">Uses the get-value syntax</a>
 
                 <button onClick={this.clear} className="btn btn-sm btn-danger" style={{ marginLeft: 'auto' }}>Clear deliveries</button>
@@ -162,13 +162,17 @@ export default class App extends Component {
               />
             </div>
             {pinnedDeliveries.length > 0 && (
-              <ul className="Box list-style-none pl-0 mb-2">
-                {filtered.filter(this.isPinned).map((item, i, arr) => {
-                  const id = item['x-github-delivery']
-                  return <ListItem key={id} pinned togglePinned={this.togglePinned} item={item} last={i === arr.length - 1} />
-                })}
-              </ul>
+              <React.Fragment>
+                <h6 className="d-flex flex-items-center text-gray mb-1"><PinIcon height={12} width={12} className="mr-1" /> Pinned</h6>
+                <ul className="Box list-style-none pl-0 mb-2">
+                  {filtered.filter(this.isPinned).map((item, i, arr) => {
+                    const id = item['x-github-delivery']
+                    return <ListItem key={id} pinned togglePinned={this.togglePinned} item={item} last={i === arr.length - 1} />
+                  })}
+                </ul>
+              </React.Fragment>
             )}
+            <h6 className="d-flex flex-items-center text-gray mb-1">All</h6>
             <ul className="Box list-style-none pl-0">
               {filtered.filter(item => !this.isPinned(item)).map((item, i, arr) => {
                 const id = item['x-github-delivery']

--- a/server/src/components/EventIcon.js
+++ b/server/src/components/EventIcon.js
@@ -1,0 +1,68 @@
+import React, { Component } from 'react'
+import { string } from 'prop-types'
+import {
+  CommentIcon,
+  CheckIcon,
+  RepoForkedIcon,
+  EyeIcon,
+  ChecklistIcon,
+  CloudUploadIcon,
+  GlobeIcon,
+  HubotIcon,
+  MilestoneIcon,
+  ProjectIcon,
+  StopIcon,
+  NoteIcon,
+  RepoPushIcon,
+  PackageIcon,
+  GitPullRequestIcon,
+  BookmarkIcon,
+  IssueOpenedIcon,
+  IssueClosedIcon
+} from 'react-octicons'
+
+const iconMap = {
+  push: <RepoPushIcon />,
+  pull_request: <GitPullRequestIcon />,
+  label: <BookmarkIcon />,
+  'issues.opened': <IssueOpenedIcon />,
+  'issues.closed': <IssueClosedIcon />,
+  issue_comment: <CommentIcon />,
+  status: <CheckIcon />,
+  fork: <RepoForkedIcon />,
+  watch: <EyeIcon />,
+  check_run: <ChecklistIcon />,
+  check_suite: <ChecklistIcon />,
+  deployment: <CloudUploadIcon />,
+  deployment_status: <CloudUploadIcon />,
+  ping: <GlobeIcon />,
+  installation: <HubotIcon />,
+  installation_repositories: <HubotIcon />,
+  milestone: <MilestoneIcon />,
+  project: <ProjectIcon />,
+  project_card: <NoteIcon />,
+  project_column: <ProjectIcon />,
+  repository_vulnerability_alert: <StopIcon />
+}
+
+export default class EventIcon extends Component {
+  static propTypes = {
+    action: string,
+    event: string.isRequired
+  }
+
+  render () {
+    const { action, event } = this.props
+    let icon
+
+    if (action && iconMap[`${event}.${action}`]) {
+      icon = iconMap[`${event}.${action}`]
+    } else if (iconMap[event]) {
+      icon = iconMap[event]
+    } else {
+      icon = <PackageIcon />
+    }
+
+    return icon
+  }
+}

--- a/server/src/components/ListItem.js
+++ b/server/src/components/ListItem.js
@@ -1,60 +1,22 @@
 import React, { Component } from 'react'
-import { object, bool } from 'prop-types'
+import { object, bool, func } from 'prop-types'
 import moment from 'moment'
 import ReactJson from 'react-json-view'
+import EventIcon from './EventIcon'
 import {
-  RepoPushIcon,
-  PackageIcon,
-  GitPullRequestIcon,
-  BookmarkIcon,
-  IssueOpenedIcon,
-  IssueClosedIcon,
   KebabHorizontalIcon,
   ClippyIcon,
   SyncIcon,
-  CommentIcon,
-  CheckIcon,
-  RepoForkedIcon,
-  EyeIcon,
-  ChecklistIcon,
-  CloudUploadIcon,
-  GlobeIcon,
-  HubotIcon,
-  MilestoneIcon,
-  ProjectIcon,
-  StopIcon,
-  NoteIcon
+  PinIcon
 } from 'react-octicons'
 import EventDescription from './EventDescription'
 import copy from 'copy-to-clipboard'
 
-const iconMap = {
-  push: <RepoPushIcon />,
-  pull_request: <GitPullRequestIcon />,
-  label: <BookmarkIcon />,
-  'issues.opened': <IssueOpenedIcon />,
-  'issues.closed': <IssueClosedIcon />,
-  issue_comment: <CommentIcon />,
-  status: <CheckIcon />,
-  fork: <RepoForkedIcon />,
-  watch: <EyeIcon />,
-  check_run: <ChecklistIcon />,
-  check_suite: <ChecklistIcon />,
-  deployment: <CloudUploadIcon />,
-  deployment_status: <CloudUploadIcon />,
-  ping: <GlobeIcon />,
-  installation: <HubotIcon />,
-  installation_repositories: <HubotIcon />,
-  milestone: <MilestoneIcon />,
-  project: <ProjectIcon />,
-  project_card: <NoteIcon />,
-  project_column: <ProjectIcon />,
-  repository_vulnerability_alert: <StopIcon />
-}
-
 export default class ListItem extends Component {
   static propTypes = {
     item: object.isRequired,
+    pinned: bool.isRequired,
+    togglePin: func.isRequired,
     last: bool.isRequired
   }
 
@@ -85,27 +47,17 @@ export default class ListItem extends Component {
 
   render () {
     const { expanded, copied, redelivered } = this.state
-    const { item, last } = this.props
+    const { item, last, pinned } = this.props
 
     const event = item['x-github-event']
     const payload = item.body
     const id = item['x-github-delivery']
 
-    let icon
-
-    if (payload.action && iconMap[`${event}.${payload.action}`]) {
-      icon = iconMap[`${event}.${payload.action}`]
-    } else if (iconMap[event]) {
-      icon = iconMap[event]
-    } else {
-      icon = <PackageIcon />
-    }
-
     return (
       <li className={`p-3 ${last ? '' : 'border-bottom'}`}>
         <div className="d-flex flex-items-center">
           <div className="mr-2" style={{ width: 16 }}>
-            {icon}
+            <EventIcon />
           </div>
           <span className="input-monospace">{event}</span>
           <time className="f6" style={{ marginLeft: 'auto' }}>{moment(item.timestamp).fromNow()}</time>
@@ -121,6 +73,14 @@ export default class ListItem extends Component {
               </div>
 
               <div>
+                <button
+                  onClick={this.pin}
+                  className="btn btn-sm tooltipped tooltipped-s"
+                  aria-label="Pin this delivery"
+                  style={{ opacity: pinned ? 1 : 0.5 }}
+                >
+                  <PinIcon />
+                </button>
                 <button
                   onBlur={() => this.setState({ copied: false })}
                   onClick={this.copy}

--- a/server/src/components/ListItem.js
+++ b/server/src/components/ListItem.js
@@ -3,12 +3,7 @@ import { object, bool, func } from 'prop-types'
 import moment from 'moment'
 import ReactJson from 'react-json-view'
 import EventIcon from './EventIcon'
-import {
-  KebabHorizontalIcon,
-  ClippyIcon,
-  SyncIcon,
-  PinIcon
-} from 'react-octicons'
+import { KebabHorizontalIcon, ClippyIcon, SyncIcon, PinIcon } from 'react-octicons'
 import EventDescription from './EventDescription'
 import copy from 'copy-to-clipboard'
 
@@ -16,7 +11,7 @@ export default class ListItem extends Component {
   static propTypes = {
     item: object.isRequired,
     pinned: bool.isRequired,
-    togglePin: func.isRequired,
+    togglePinned: func.isRequired,
     last: bool.isRequired
   }
 
@@ -47,7 +42,7 @@ export default class ListItem extends Component {
 
   render () {
     const { expanded, copied, redelivered } = this.state
-    const { item, last, pinned } = this.props
+    const { item, last, pinned, togglePinned } = this.props
 
     const event = item['x-github-event']
     const payload = item.body
@@ -57,7 +52,7 @@ export default class ListItem extends Component {
       <li className={`p-3 ${last ? '' : 'border-bottom'}`}>
         <div className="d-flex flex-items-center">
           <div className="mr-2" style={{ width: 16 }}>
-            <EventIcon />
+            <EventIcon event={event} action={payload.action} />
           </div>
           <span className="input-monospace">{event}</span>
           <time className="f6" style={{ marginLeft: 'auto' }}>{moment(item.timestamp).fromNow()}</time>
@@ -74,17 +69,14 @@ export default class ListItem extends Component {
 
               <div>
                 <button
-                  onClick={this.pin}
-                  className="btn btn-sm tooltipped tooltipped-s"
+                  onClick={() => togglePinned(id)}
+                  className={`btn btn-sm tooltipped tooltipped-s ${pinned && 'text-blue'}`}
                   aria-label="Pin this delivery"
-                  style={{ opacity: pinned ? 1 : 0.5 }}
-                >
-                  <PinIcon />
-                </button>
+                ><PinIcon /></button>
                 <button
                   onBlur={() => this.setState({ copied: false })}
                   onClick={this.copy}
-                  className="btn btn-sm tooltipped tooltipped-s js-copy-btn"
+                  className="ml-2 btn btn-sm tooltipped tooltipped-s js-copy-btn"
                   aria-label={copied ? 'Copied!' : 'Copy payload to clipboard'}
                 ><ClippyIcon /></button>
                 <button

--- a/server/tests/App.test.js
+++ b/server/tests/App.test.js
@@ -116,4 +116,17 @@ describe('<App />', () => {
       expect(localStorage.setItem).not.toHaveBeenCalled()
     })
   })
+
+  describe('togglePinned', () => {
+    it('adds a pinned item to the array', () => {
+      wrapper.instance().togglePinned(123)
+      expect(wrapper.state('pinnedDeliveries')).toEqual([123])
+    })
+
+    it('removes a pinned item from the array', () => {
+      wrapper.setState({ pinnedDeliveries: [123] })
+      wrapper.instance().togglePinned(123)
+      expect(wrapper.state('pinnedDeliveries')).toEqual([])
+    })
+  })
 })

--- a/server/tests/App.test.js
+++ b/server/tests/App.test.js
@@ -128,5 +128,11 @@ describe('<App />', () => {
       wrapper.instance().togglePinned(123)
       expect(wrapper.state('pinnedDeliveries')).toEqual([])
     })
+
+    it('stores the pinnedDeliveries in localStorage', () => {
+      wrapper.instance().togglePinned(123)
+      expect(localStorage.setItem.mock.calls[0][0]).toBe('smee:log:CHANNEL:pinnedDeliveries')
+      expect(localStorage.setItem.mock.calls[0][1]).toMatchSnapshot()
+    })
   })
 })

--- a/server/tests/App.test.js
+++ b/server/tests/App.test.js
@@ -11,7 +11,8 @@ describe('<App />', () => {
   beforeEach(() => {
     localStorage = {
       getItem: jest.fn(),
-      setItem: jest.fn()
+      setItem: jest.fn(),
+      removeItem: jest.fn()
     }
 
     const EventSource = jest.fn()
@@ -114,6 +115,27 @@ describe('<App />', () => {
 
       expect(wrapper.state('log').length).toBe(1)
       expect(localStorage.setItem).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('clear', () => {
+    beforeEach(() => {
+      window.confirm = jest.fn(() => true)
+      const item = { 'x-github-delivery': 123 }
+      wrapper.setState({ log: [item] })
+    })
+
+    it('clears the log state and localStorage', () => {
+      wrapper.instance().clear()
+      expect(wrapper.state('log')).toEqual([])
+      expect(localStorage.removeItem).toHaveBeenCalled()
+    })
+
+    it('does not clear pinned deliveries', () => {
+      wrapper.instance().togglePinned(123)
+      wrapper.instance().clear()
+      expect(wrapper.state('log')).toMatchSnapshot()
+      expect(localStorage.setItem.mock.calls[0][1]).toMatchSnapshot()
     })
   })
 

--- a/server/tests/App.test.js
+++ b/server/tests/App.test.js
@@ -131,8 +131,12 @@ describe('<App />', () => {
 
     it('stores the pinnedDeliveries in localStorage', () => {
       wrapper.instance().togglePinned(123)
-      expect(localStorage.setItem.mock.calls[0][0]).toBe('smee:log:CHANNEL:pinnedDeliveries')
+      expect(localStorage.setItem.mock.calls[0][0]).toBe('smee:log:CHANNEL:pinned')
       expect(localStorage.setItem.mock.calls[0][1]).toMatchSnapshot()
+
+      wrapper.instance().togglePinned(123)
+      expect(localStorage.setItem.mock.calls[1][0]).toBe('smee:log:CHANNEL:pinned')
+      expect(localStorage.setItem.mock.calls[1][1]).toMatchSnapshot()
     })
   })
 })

--- a/server/tests/EventIcon.test.js
+++ b/server/tests/EventIcon.test.js
@@ -1,0 +1,22 @@
+import React from 'react'
+import EventIcon from '../src/components/EventIcon'
+import { shallow } from 'enzyme'
+
+describe('<EventIcon />', () => {
+  describe('render', () => {
+    it('should render the correct octicon', () => {
+      const wrapper = shallow(<EventIcon event="ping" />)
+      expect(wrapper.find('GlobeIcon').length).toBe(1)
+    })
+
+    it('renders the correct octicon if there an action', () => {
+      const wrapper = shallow(<EventIcon event="issues" action="opened" />)
+      expect(wrapper.find('IssueOpenedIcon').length).toBe(1)
+    })
+
+    it('renders the package octicon if the event is unknown', () => {
+      const wrapper = shallow(<EventIcon event="nothing" />)
+      expect(wrapper.find('PackageIcon').length).toBe(1)
+    })
+  })
+})

--- a/server/tests/ListItem.test.js
+++ b/server/tests/ListItem.test.js
@@ -3,7 +3,7 @@ import ListItem from '../src/components/ListItem'
 import { shallow } from 'enzyme'
 
 describe('<ListItem />', () => {
-  let item, el
+  let item, el, togglePinned
 
   beforeEach(() => {
     item = {
@@ -12,7 +12,9 @@ describe('<ListItem />', () => {
       body: { action: 'opened' }
     }
 
-    el = shallow(<ListItem last item={item} />)
+    togglePinned = jest.fn()
+
+    el = shallow(<ListItem last item={item} pinned={false} togglePinned={togglePinned} />)
   })
 
   describe('redeliver', () => {
@@ -36,22 +38,6 @@ describe('<ListItem />', () => {
 
       el.find('button.ellipsis-expander').simulate('click')
       expect(el.children().length).toBe(2)
-    })
-
-    it('renders the correct octicon if there is no action', () => {
-      const i = { ...item, 'x-github-event': 'test' }
-      const wrapper = shallow(<ListItem last item={i} />)
-      expect(wrapper.find('PackageIcon').length).toBe(1)
-    })
-
-    it('renders the package octicon if the event is unknown', () => {
-      const i = {
-        'x-github-event': 'push',
-        timestamp: 1513148474751,
-        body: {}
-      }
-      const wrapper = shallow(<ListItem last item={i} />)
-      expect(wrapper.find('RepoPushIcon').length).toBe(1)
     })
   })
 

--- a/server/tests/__snapshots__/App.test.js.snap
+++ b/server/tests/__snapshots__/App.test.js.snap
@@ -1,5 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<App /> clear does not clear pinned deliveries 1`] = `
+Array [
+  Object {
+    "x-github-delivery": 123,
+  },
+]
+`;
+
+exports[`<App /> clear does not clear pinned deliveries 2`] = `"[123]"`;
+
 exports[`<App /> onmessage adds the new log to the state and localStorage 1`] = `"[{\\"x-github-delivery\\":123}]"`;
 
 exports[`<App /> togglePinned stores the pinnedDeliveries in localStorage 1`] = `"[123]"`;

--- a/server/tests/__snapshots__/App.test.js.snap
+++ b/server/tests/__snapshots__/App.test.js.snap
@@ -1,3 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<App /> onmessage adds the new log to the state and localStorage 1`] = `"[{\\"x-github-delivery\\":123}]"`;
+
+exports[`<App /> togglePinned stores the pinnedDeliveries in localStorage 1`] = `"[123]"`;
+
+exports[`<App /> togglePinned stores the pinnedDeliveries in localStorage 2`] = `"[]"`;


### PR DESCRIPTION
Adds functionality for pinned events. This is to ensure that some events don't get deleted, and always stay at the top of the UI. I've wanted this kind of functionality when building a Probot App that requires a specific payload, and I've seen important payloads get lost in a big list.

Here's how it looks (where `installation` is pinned):

![image](https://user-images.githubusercontent.com/10660468/40033695-857ffbc8-57c7-11e8-8f83-d3b2ef2197e1.png)

And the button to make it happen:

![image](https://user-images.githubusercontent.com/10660468/40033713-99793770-57c7-11e8-8431-85cb54621f1a.png)


## Todo:

- [x] Persist `pinnedDeliveries` to `localStorage`
- [x] Pass existing tests
- [x] Write new tests

Closes #53 