### PR TITLE
Fix button alignment

### DIFF
--- a/server/src/components/ListItem.js
+++ b/server/src/components/ListItem.js
@@ -67,7 +67,7 @@ export default class ListItem extends Component {
                 <EventDescription event={event} payload={payload} timestamp={item.timestamp} />
               </div>
 
-              <div>
+              <div className="d-flex ml-2">
                 <button
                   onClick={() => togglePinned(id)}
                   className={`btn btn-sm tooltipped tooltipped-s ${pinned && 'text-blue'}`}


### PR DESCRIPTION
An alignment bug was introduced in #55 where a long paragraph caused the buttons to wrap to a second line. Thanks to @tcbyrd for pointing it out 💪 🎯 

![image](https://user-images.githubusercontent.com/10660468/40246823-322b5d72-5a98-11e8-8e24-610e9064924d.png)
