### PR TITLE
Change copy output to work as a fixture

### DIFF
--- a/server/src/components/ListItem.js
+++ b/server/src/components/ListItem.js
@@ -24,7 +24,9 @@ export default class ListItem extends Component {
   }
 
   copy () {
-    const copied = copy(JSON.stringify(this.props.item))
+    const { item } = this.props
+    const event = { event: item['x-github-event'], payload: item.body }
+    const copied = copy(JSON.stringify(event))
     this.setState({ copied })
   }
 


### PR DESCRIPTION
Acting on some feedback from @gautam & @johnkpaul, this PR changes the output of the `Copy` button to conform to what `robot.receive()` actually receives. Previously, the entire request was copied (headers, body); now, only the event and payload are copied. Specifically this:

```js
{
  event: item['x-github-event'],
  payload: item.body
}
```