### PR TITLE
Add raven to send errors to sentry

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -82,5 +82,10 @@
     "testPathIgnorePatterns": [
       "/node_modules/"
     ]
+  },
+  "standard": {
+    "env": [
+      "jest"
+    ]
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -44,6 +44,7 @@
     "prop-types": "^15.6.0",
     "purify-css": "^1.2.5",
     "purifycss-webpack": "^0.7.0",
+    "raven": "^2.6.3",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-json-view": "^1.13.2",

--- a/server/server.js
+++ b/server/server.js
@@ -11,10 +11,13 @@ const KeepAlive = require('./keep-alive')
 // Tiny logger to prevent logs in tests
 const log = process.env.NODE_ENV === 'test' ? _ => _ : console.log
 
-module.exports = () => {
+module.exports = (testRoute) => {
   const events = new EventEmitter()
   const app = express()
   const pubFolder = path.join(__dirname, 'public')
+
+  // Used for testing route error handling
+  if (testRoute) testRoute(app)
 
   if (process.env.SENTRY_DSN) {
     Raven.config(process.env.SENTRY_DSN).install()
@@ -95,10 +98,6 @@ module.exports = () => {
   app.post('/:channel/redeliver', (req, res) => {
     events.emit(req.params.channel, req.body)
     res.status(200).end()
-  })
-
-  app.get('/not/a/valid/url', (req, res) => {
-    throw new Error('an error')
   })
 
   if (process.env.SENTRY_DSN) {

--- a/server/server.js
+++ b/server/server.js
@@ -16,8 +16,10 @@ module.exports = () => {
   const app = express()
   const pubFolder = path.join(__dirname, 'public')
 
-  Raven.config(process.env.SENTRY_DSN).install()
-  app.use(Raven.requestHandler())
+  if (process.env.SENTRY_DSN) {
+    Raven.config(process.env.SENTRY_DSN).install()
+    app.use(Raven.requestHandler())
+  }
 
   if (process.env.FORCE_HTTPS) {
     app.use(require('helmet')())
@@ -95,6 +97,9 @@ module.exports = () => {
     res.status(200).end()
   })
 
-  app.use(Raven.errorHandler())
+  if (process.env.SENTRY_DSN) {
+    app.use(Raven.errorHandler())
+  }
+
   return app
 }

--- a/server/server.js
+++ b/server/server.js
@@ -97,6 +97,10 @@ module.exports = () => {
     res.status(200).end()
   })
 
+  app.get('/not/a/valid/url', (req, res) => {
+    throw new Error('an error')
+  })
+
   if (process.env.SENTRY_DSN) {
     app.use(Raven.errorHandler())
   }

--- a/server/server.js
+++ b/server/server.js
@@ -4,6 +4,7 @@ const crypto = require('crypto')
 const bodyParser = require('body-parser')
 const EventEmitter = require('events')
 const path = require('path')
+const Raven = require('raven')
 
 const KeepAlive = require('./keep-alive')
 
@@ -14,6 +15,9 @@ module.exports = () => {
   const events = new EventEmitter()
   const app = express()
   const pubFolder = path.join(__dirname, 'public')
+
+  Raven.config(process.env.SENTRY_DSN).install()
+  app.use(Raven.requestHandler())
 
   if (process.env.FORCE_HTTPS) {
     app.use(require('helmet')())
@@ -91,5 +95,6 @@ module.exports = () => {
     res.status(200).end()
   })
 
+  app.use(Raven.errorHandler())
   return app
 }

--- a/server/tests/server.test.js
+++ b/server/tests/server.test.js
@@ -15,9 +15,13 @@ describe('Sentry tests', () => {
     expect(server).toBeTruthy()
   })
 
-  it('reports errors to Sentry', () => {
+  it('reports errors to Sentry', async () => {
     process.env.SENTRY_DSN = 'https://user:pw@sentry.io/1234'
-    request(server).get('/not/a/valid/url')
+
+    // Pass a route that errors, just to test it
+    app = createServer(a => a.get('/not/a/valid/url', () => { throw new Error('test') }))
+
+    await request(app).get('/not/a/valid/url')
     expect(Raven.captureException).toHaveBeenCalled()
   })
 


### PR DESCRIPTION
This gets us part of the way towards #64 by sending errors to Sentry. Thinking we'll put it in the same Organization as the other Probot apps we host internally ([test issue](https://sentry.io/probot/smeeio/issues/604239965/))

- [ ] Once this is deployed, we'll need to add the `SENTRY_DSN` env variable in Heroku