### PR TITLE
Add descriptive page titles

### DIFF
--- a/server/public/index.html
+++ b/server/public/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>smee.io</title>
+  <title>smee.io | Webhook payload delivery service</title>
   <link rel="shortcut icon" href="/public/favicon.png">
   <link rel="stylesheet" href="/public/main.min.css">
 </head>

--- a/server/public/webhooks.html
+++ b/server/public/webhooks.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Webhooks</title>
+  <title>smee.io | Webhook deliveries</title>
   <link rel="shortcut icon" href="/public/favicon.png">
   <link rel="stylesheet" href="/public/main.min.css">
 </head>

--- a/server/tests/__snapshots__/server.test.js.snap
+++ b/server/tests/__snapshots__/server.test.js.snap
@@ -7,7 +7,7 @@ exports[`server GET / returns the proper HTML 1`] = `
   <meta charset=\\"UTF-8\\">
   <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1.0\\">
   <meta http-equiv=\\"X-UA-Compatible\\" content=\\"ie=edge\\">
-  <title>smee.io</title>
+  <title>smee.io | Webhook payload delivery service</title>
   <link rel=\\"shortcut icon\\" href=\\"/public/favicon.png\\">
   <link rel=\\"stylesheet\\" href=\\"/public/main.min.css\\">
 </head>
@@ -68,7 +68,7 @@ exports[`server GET /:channel returns the proper HTML 1`] = `
   <meta charset=\\"UTF-8\\">
   <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1.0\\">
   <meta http-equiv=\\"X-UA-Compatible\\" content=\\"ie=edge\\">
-  <title>Webhooks</title>
+  <title>smee.io | Webhook deliveries</title>
   <link rel=\\"shortcut icon\\" href=\\"/public/favicon.png\\">
   <link rel=\\"stylesheet\\" href=\\"/public/main.min.css\\">
 </head>


### PR DESCRIPTION
Update page titles to be more descriptive.

Often when needing to use [Smee.io](Smee.io) I'll type "webhook", unfortunately the main page title is not descriptive enough to show the site as a result.

See: https://support.google.com/webmasters/answer/35624 for general guidelines on page titles.