### PR TITLE
Fix console warning in server.js test

### DIFF
--- a/server/tests/server.test.js
+++ b/server/tests/server.test.js
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 const createServer = require('../server')
 const request = require('supertest')
 const EventSource = require('eventsource')


### PR DESCRIPTION
Jest's default [test environment](https://jestjs.io/docs/en/configuration.html#testenvironment-string) is jsdom, and when running the tests on master, the following warning is logged in `server.test.js`:

```
❯ npm test

> smee-server@0.0.3 test /Users/macklinu/dev/probot/smee/server
> jest --coverage && eslint '**/*.js'

 PASS  tests/server.test.js
  ● Console

    console.warn node_modules/raven/lib/utils.js:147
      raven@2.6.4 alert: This looks like a browser environment; are you sure you don't want Raven.js for browser JavaScript? https://sentry.io/for/javascript

 PASS  tests/App.test.js
 PASS  tests/ListItem.test.js
 PASS  tests/Blank.test.js
 PASS  tests/EventIcon.test.js
 PASS  tests/EventDescription.test.js

Test Suites: 6 passed, 6 total
Tests:       38 passed, 38 total
Snapshots:   8 passed, 8 total
Time:        2.115s
Ran all test suites.
```

By setting the test environment in `server.test.js` to node, this warning is removed (this output is from this branch):

```
❯ npm test

> smee-server@0.0.3 test /Users/macklinu/dev/probot/smee/server
> jest --coverage && eslint '**/*.js'

 PASS  tests/App.test.js
 PASS  tests/server.test.js
 PASS  tests/ListItem.test.js
 PASS  tests/Blank.test.js
 PASS  tests/EventIcon.test.js
 PASS  tests/EventDescription.test.js

Test Suites: 6 passed, 6 total
Tests:       38 passed, 38 total
Snapshots:   8 passed, 8 total
Time:        1.978s
Ran all test suites.
```