### PR TITLE
Add support for target argument

### DIFF
--- a/client/bin/smee.js
+++ b/client/bin/smee.js
@@ -7,11 +7,17 @@ const Client = require('..')
 program
   .usage('[options]')
   .option('-u, --url <url>', 'URL of the webhook proxy service. Default: https://smee.io/new')
+  .option('-t, --target <target>', 'URL of the target service the events will forwarded to. Default: http://127.0.0.1:port/path')
   .option('-p, --port <n>', 'Local HTTP server port', process.env.PORT || 3000)
   .option('-P, --path <path>', 'URL path to post proxied requests to`', '/')
   .parse(process.argv)
 
-const target = `http://127.0.0.1:${program.port}${program.path}`
+let target
+if (program.target) {
+  target = program.target
+} else {
+  target = `http://127.0.0.1:${program.port}${program.path}`
+}
 
 async function setup () {
   let source = program.url


### PR DESCRIPTION
### Context

I'd like to use smee in a docker-compose service to redirect GitHub events to a Rails instance which is running in another service.

I tried to use smee for that by installing it globally and calling it with the right arguments but I realized that it's not possible to pass the target through arguments. It defaults to `127.0.0.1:port/path`.

### What
I've added support for a new argument, target. When passed, that target is used to initialize the client.