### PR TITLE
Add version option to client CLI

### DIFF
--- a/client/bin/smee.js
+++ b/client/bin/smee.js
@@ -1,10 +1,12 @@
 #!/usr/bin/env node
 
 const program = require('commander')
+const { version } = require('../package.json')
 
 const Client = require('..')
 
 program
+  .version(version, '-v, --version')
   .usage('[options]')
   .option('-u, --url <url>', 'URL of the webhook proxy service. Default: https://smee.io/new')
   .option('-t, --target <target>', 'Full URL (including protocol and path) of the target service the events will forwarded to. Default: http://127.0.0.1:PORT/PATH')

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smee-client",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Client to proxy webhooks to local host",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Pulls in the version number from `package.json` and is returned when running `smee` with the `-v` or `--version` option.
Fixes #95 